### PR TITLE
Add get method to DerivVariable (#17)

### DIFF
--- a/core/DerivVariable.m
+++ b/core/DerivVariable.m
@@ -101,6 +101,15 @@ classdef DerivVariable < handle
             out = numel(obj.values) - 1;
         end
         
+        function out = get(obj, varargin)
+            newValues = cell(size(obj.values));
+            for j = 1:numel(obj.values)
+                temp = obj.values{j};
+                newValues{j} = temp(varargin{:});
+            end
+            out = DerivVariable(newValues{:});
+        end
+        
         function out = flatValue(obj)
             d = prod(obj.shape);
             N = obj.order;


### PR DESCRIPTION
Subcomponents of a `DerivVariable` object can be referenced using the `get` method.